### PR TITLE
Fixed handling default value case differently by using a literal equality operator.

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -213,7 +213,7 @@ Keyset.prototype = {
       // Handle '(Default)' value differently
       var params = name === "(Default)" ? [ 
         q(this.path),           // parent's reg path
-        '/ve',          // default value flag
+        '/ve',                  // default value flag
         '/d', this[name].raw,   // registry formatted data
         '/f'
       ] : [

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -210,7 +210,13 @@ Keyset.prototype = {
     if (typeof(value) !== 'undefined' && value !== null) {
       // individual value
       this[name] = new Entry(this, { name: name, value: value });
-      var params = [
+      // Handle '(Default)' value differently
+      var params = name === "(Default)" ? [ 
+        q(this.path),           // parent's reg path
+        '/ve',          // default value flag
+        '/d', this[name].raw,   // registry formatted data
+        '/f'
+      ] : [
         q(this.path),           // parent's reg path
         '/v', q(name),          // quoted value
         '/t', this[name].type,  // RegType


### PR DESCRIPTION
By using the string literal "(Default)" as the key name, the params array will switch to using the `/ve` flag instead, and removes the `/t` (Type) flag. This allows for a more seamless experience while using the registry package.

Other solutions that were explored:
- Adding a new boolean parameter to the 'add' function which allows one to declare the value as default
- Adding a new object parameter that can contain many different options to change the flags that are generated, one of which would include the default value flag.

However, out of the three, simply detecting the "(Default)" value and taking the necessary steps to make a value default, was more intuitive and less invasive in total. Thus allowing better continuity between current versions and newer versions of the registry package. 

<sup>via Microart Grendel 3 (Git interop v2.15.0)</sup>