### PR TITLE
update runnable.js, so it won't throw error when not used

### DIFF
--- a/lib/runnable.js
+++ b/lib/runnable.js
@@ -23,16 +23,16 @@ if (PATH.length === 1) {
   }
 }
 
-//Bugfix taken from @schmittberger
-if (!exists(PATH)) {
-  if (process.env.NODE_PATH) {
-    PATH = process.env.NODE_PATH
-  } else {
-    throw new Error('No bin-PATH found');
-  }
-}
-
 module.exports = function runnable(files){
+  //Bugfix taken from @schmittberger
+  if (!exists(PATH)) {
+    if (process.env.NODE_PATH) {
+      PATH = process.env.NODE_PATH
+    } else {
+      throw new Error('No bin-PATH found');
+    }
+  }
+
   return files.map(function(file){
     if (exists(file)) {
       var parts = {


### PR DESCRIPTION
Currently when using the 'windows' package in electron - it throws an error for people who don't have node installed. I think it's better to move this error throw to the "running" method. So if I don't use this - no error will be thrown.